### PR TITLE
Add shivjm.name and package-lock.json

### DIFF
--- a/src/_data/sites/shivjm-name.json
+++ b/src/_data/sites/shivjm-name.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://shivjm.name/",
+  "title": "‘Shiv Jha-Mathur’: Demystifying The Hyphen",
+  "description": "An explanation of my name.",
+  "launchDate": "2021-10-28",
+  "author": "Shiv J.M.",
+  "authorSite": "https://shivjm.blog/"
+}


### PR DESCRIPTION
While I was adding the site, I noticed package-lock.json was in .gitignore, which makes the build less predictable and reproducible. I removed that line and committed the file to allow using <kbd>npm ci</kbd>. Let me know in case you don’t want that and I’ll remove the second commit.